### PR TITLE
[Hardware Wallet Support Milestone 2] ECDSA Custom Signature Pallet UI implementation

### DIFF
--- a/packages/apps-routing/src/custom-signature.ts
+++ b/packages/apps-routing/src/custom-signature.ts
@@ -1,0 +1,22 @@
+// Copyright 2017-2020 @polkadot/apps-routing authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { TFunction } from 'i18next';
+import type { Route } from './types';
+
+import Component from '@polkadot/app-custom-signature';
+
+export default function create (t: TFunction): Route {
+  return {
+    Component,
+    display: {
+      needsApi: [
+        'tx.ethCall.call'
+      ]
+    },
+    group: 'accounts',
+    icon: 'signature',
+    name: 'custom-signature',
+    text: t('nav.custom-signature', 'Custom Signature', { ns: 'apps-routing' })
+  };
+}

--- a/packages/apps-routing/src/index.ts
+++ b/packages/apps-routing/src/index.ts
@@ -11,6 +11,7 @@ import calendar from './calendar';
 import claims from './claims';
 import contracts from './contracts';
 import council from './council';
+import customSignature from './custom-signature';
 import democracy from './democracy';
 import explorer from './explorer';
 import extrinsics from './extrinsics';
@@ -34,6 +35,7 @@ export default function create (t: TFunction): Routes {
     addresses(t),
     explorer(t),
     claims(t),
+    customSignature(t),
     poll(t),
     transfer(t),
     staking(t),

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@types/punycode": "^2.1.0",
+    "assert": "^2.0.0",
     "babel-loader": "^8.2.2",
     "buffer": "^6.0.3",
     "copy-webpack-plugin": "^7.0.0",

--- a/packages/apps/webpack.base.js
+++ b/packages/apps/webpack.base.js
@@ -174,6 +174,7 @@ function createWebpack (context, mode = 'production') {
       },
       extensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
       fallback: {
+        assert: require.resolve('assert'),
         crypto: require.resolve('crypto-browserify'),
         path: require.resolve('path-browserify'),
         stream: require.resolve('stream-browserify')

--- a/packages/page-custom-signature/LICENSE
+++ b/packages/page-custom-signature/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                    http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+  "License" shall mean the terms and conditions for use, reproduction,
+  and distribution as defined by Sections 1 through 9 of this document.
+
+  "Licensor" shall mean the copyright owner or entity authorized by
+  the copyright owner that is granting the License.
+
+  "Legal Entity" shall mean the union of the acting entity and all
+  other entities that control, are controlled by, or are under common
+  control with that entity. For the purposes of this definition,
+  "control" means (i) the power, direct or indirect, to cause the
+  direction or management of such entity, whether by contract or
+  otherwise, or (ii) ownership of fifty percent (50%) or more of the
+  outstanding shares, or (iii) beneficial ownership of such entity.
+
+  "You" (or "Your") shall mean an individual or Legal Entity
+  exercising permissions granted by this License.
+
+  "Source" form shall mean the preferred form for making modifications,
+  including but not limited to software source code, documentation
+  source, and configuration files.
+
+  "Object" form shall mean any form resulting from mechanical
+  transformation or translation of a Source form, including but
+  not limited to compiled object code, generated documentation,
+  and conversions to other media types.
+
+  "Work" shall mean the work of authorship, whether in Source or
+  Object form, made available under the License, as indicated by a
+  copyright notice that is included in or attached to the work
+  (an example is provided in the Appendix below).
+
+  "Derivative Works" shall mean any work, whether in Source or Object
+  form, that is based on (or derived from) the Work and for which the
+  editorial revisions, annotations, elaborations, or other modifications
+  represent, as a whole, an original work of authorship. For the purposes
+  of this License, Derivative Works shall not include works that remain
+  separable from, or merely link (or bind by name) to the interfaces of,
+  the Work and Derivative Works thereof.
+
+  "Contribution" shall mean any work of authorship, including
+  the original version of the Work and any modifications or additions
+  to that Work or Derivative Works thereof, that is intentionally
+  submitted to Licensor for inclusion in the Work by the copyright owner
+  or by an individual or Legal Entity authorized to submit on behalf of
+  the copyright owner. For the purposes of this definition, "submitted"
+  means any form of electronic, verbal, or written communication sent
+  to the Licensor or its representatives, including but not limited to
+  communication on electronic mailing lists, source code control systems,
+  and issue tracking systems that are managed by, or on behalf of, the
+  Licensor for the purpose of discussing and improving the Work, but
+  excluding communication that is conspicuously marked or otherwise
+  designated in writing by the copyright owner as "Not a Contribution."
+
+  "Contributor" shall mean Licensor and any individual or Legal Entity
+  on behalf of whom a Contribution has been received by Licensor and
+  subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  copyright license to reproduce, prepare Derivative Works of,
+  publicly display, publicly perform, sublicense, and distribute the
+  Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+  this License, each Contributor hereby grants to You a perpetual,
+  worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+  (except as stated in this section) patent license to make, have made,
+  use, offer to sell, sell, import, and otherwise transfer the Work,
+  where such license applies only to those patent claims licensable
+  by such Contributor that are necessarily infringed by their
+  Contribution(s) alone or by combination of their Contribution(s)
+  with the Work to which such Contribution(s) was submitted. If You
+  institute patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that the Work
+  or a Contribution incorporated within the Work constitutes direct
+  or contributory patent infringement, then any patent licenses
+  granted to You under this License for that Work shall terminate
+  as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+  Work or Derivative Works thereof in any medium, with or without
+  modifications, and in Source or Object form, provided that You
+  meet the following conditions:
+
+  (a) You must give any other recipients of the Work or
+      Derivative Works a copy of this License; and
+
+  (b) You must cause any modified files to carry prominent notices
+      stating that You changed the files; and
+
+  (c) You must retain, in the Source form of any Derivative Works
+      that You distribute, all copyright, patent, trademark, and
+      attribution notices from the Source form of the Work,
+      excluding those notices that do not pertain to any part of
+      the Derivative Works; and
+
+  (d) If the Work includes a "NOTICE" text file as part of its
+      distribution, then any Derivative Works that You distribute must
+      include a readable copy of the attribution notices contained
+      within such NOTICE file, excluding those notices that do not
+      pertain to any part of the Derivative Works, in at least one
+      of the following places: within a NOTICE text file distributed
+      as part of the Derivative Works; within the Source form or
+      documentation, if provided along with the Derivative Works; or,
+      within a display generated by the Derivative Works, if and
+      wherever such third-party notices normally appear. The contents
+      of the NOTICE file are for informational purposes only and
+      do not modify the License. You may add Your own attribution
+      notices within Derivative Works that You distribute, alongside
+      or as an addendum to the NOTICE text from the Work, provided
+      that such additional attribution notices cannot be construed
+      as modifying the License.
+
+  You may add Your own copyright statement to Your modifications and
+  may provide additional or different license terms and conditions
+  for use, reproduction, or distribution of Your modifications, or
+  for any such Derivative Works as a whole, provided Your use,
+  reproduction, and distribution of the Work otherwise complies with
+  the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+  any Contribution intentionally submitted for inclusion in the Work
+  by You to the Licensor shall be under the terms and conditions of
+  this License, without any additional terms or conditions.
+  Notwithstanding the above, nothing herein shall supersede or modify
+  the terms of any separate license agreement you may have executed
+  with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+  names, trademarks, service marks, or product names of the Licensor,
+  except as required for reasonable and customary use in describing the
+  origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+  agreed to in writing, Licensor provides the Work (and each
+  Contributor provides its Contributions) on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied, including, without limitation, any warranties or conditions
+  of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+  PARTICULAR PURPOSE. You are solely responsible for determining the
+  appropriateness of using or redistributing the Work and assume any
+  risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+  whether in tort (including negligence), contract, or otherwise,
+  unless required by applicable law (such as deliberate and grossly
+  negligent acts) or agreed to in writing, shall any Contributor be
+  liable to You for damages, including any direct, indirect, special,
+  incidental, or consequential damages of any character arising as a
+  result of this License or out of the use or inability to use the
+  Work (including but not limited to damages for loss of goodwill,
+  work stoppage, computer failure or malfunction, or any and all
+  other commercial damages or losses), even if such Contributor
+  has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+  the Work or Derivative Works thereof, You may choose to offer,
+  and charge a fee for, acceptance of support, warranty, indemnity,
+  or other liability obligations and/or rights consistent with this
+  License. However, in accepting such obligations, You may act only
+  on Your own behalf and on Your sole responsibility, not on behalf
+  of any other Contributor, and only if You agree to indemnify,
+  defend, and hold each Contributor harmless for any liability
+  incurred by, or claims asserted against, such Contributor by reason
+  of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+  To apply the Apache License to your work, attach the following
+  boilerplate notice, with the fields enclosed by brackets "[]"
+  replaced with your own identifying information. (Don't include
+  the brackets!)  The text should be enclosed in the appropriate
+  comment syntax for the file format. We also recommend that a
+  file or class name and description of purpose be included on the
+  same "printed page" as the copyright notice for easier
+  identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/page-custom-signature/README.md
+++ b/packages/page-custom-signature/README.md
@@ -1,0 +1,1 @@
+# @polkadot/app-custom-signature

--- a/packages/page-custom-signature/package.json
+++ b/packages/page-custom-signature/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@polkadot/app-custom-signature",
+  "private": true,
+  "version": "0.73.2-13",
+  "description": "A basic app for using the custom-signature Substrate Pallet",
+  "main": "index.js",
+  "scripts": {},
+  "author": "Hoon Kim <hoonkim@stake.jp.co>",
+  "maintainers": [],
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@babel/runtime": "^7.12.5",
+    "@polkadot/react-components": "^0.75.2-53",
+    "ethereumjs-util": "^7.0.7",
+    "secp256k1": "^3.8.0"
+  }
+}

--- a/packages/page-custom-signature/src/EcdsaCallSigner/CustomSignTx.tsx
+++ b/packages/page-custom-signature/src/EcdsaCallSigner/CustomSignTx.tsx
@@ -1,0 +1,132 @@
+// Copyright 2017-2020 @polkadot/app-custom-signature authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { SubmittableExtrinsic } from '@polkadot/api/types';
+
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+
+import { Button, Extrinsic, Icon, Modal, TxButton } from '@polkadot/react-components';
+import { useApi, useToggle } from '@polkadot/react-hooks';
+import { u8aToHex } from '@polkadot/util';
+
+import { useTranslation } from '../translate';
+
+interface Props {
+  // method that takes the payload and returns its signature
+  onClickSignTx: (payload: string) => Promise<string | undefined>;
+  // the ss58 encoded address of the sender
+  sender: string;
+  className?: string;
+}
+
+function CustomSignTx ({ className, onClickSignTx, sender }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const { api } = useApi();
+  const [method, setMethod] = useState<SubmittableExtrinsic<'promise'> | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+  const [callSignature, setCallSignature] = useState<string>();
+  // internal message state
+  const [errorMessage, setErrorMessage] = useState<Error>();
+
+  const [isModalOpen, toggleModalView] = useToggle();
+
+  const _onChangeExtrinsic = useCallback(
+    (method: SubmittableExtrinsic<'promise'> | null = null) => {
+      // reset the signature if the user changes the extrinsic
+      setCallSignature(undefined);
+      setMethod(() => method);
+    }, []
+  );
+
+  const _onClickSignCall = useCallback(async () => {
+    if (method) {
+      setIsBusy(true);
+      // fixme: the call serialization method is different from what the chain is expecting, which will spit a `Bad Signature` error
+      const callPayload = u8aToHex(method.toU8a(true).slice(1));
+
+      try {
+        // reset the error message if it already exists
+        if (typeof errorMessage !== 'undefined') {
+          setErrorMessage(undefined);
+        }
+
+        const callSig = await onClickSignTx(callPayload);
+
+        setCallSignature(callSig);
+
+        if (!isModalOpen) {
+          toggleModalView();
+        }
+      } catch (err) {
+        console.log(err);
+        setErrorMessage(err);
+      } finally {
+        setIsBusy(false);
+      }
+    }
+  }, [errorMessage, method, onClickSignTx, isModalOpen, toggleModalView]);
+
+  // transaction confirmation modal
+  const TransactionModal = useCallback(() => {
+    return (
+      <>
+        <Modal
+          className='app--accounts-Modal'
+          header={t<string>('Transaction Confirmation')}
+          size='large'
+        >
+          <Modal.Content>
+            <Modal.Columns>
+              <p>{t<string>('Submit the signed transaction to the chain.')}</p>
+            </Modal.Columns>
+          </Modal.Content>
+          <Modal.Actions onCancel={toggleModalView}>
+            <TxButton
+              icon='paper-plane'
+              isDisabled={!callSignature}
+              isUnsigned
+              label={t<string>('Send Transaction')}
+              onStart={toggleModalView}
+              params={[method, sender, callSignature]}
+              tx={api.tx.ethCall.call}
+              withSpinner
+            />
+          </Modal.Actions>
+        </Modal>
+      </>
+    );
+  }, [t, method, sender, callSignature, api, toggleModalView]);
+
+  return (
+    <div className={className}>
+      <Extrinsic
+        defaultValue={api.tx.balances.transfer}
+        label={t<string>('submit the following extrinsic')}
+        onChange={_onChangeExtrinsic}
+      />
+      <Button.Group>
+        {callSignature && isModalOpen && <TransactionModal />}
+        <Button
+          icon='sign-in-alt'
+          isBusy={isBusy || isModalOpen}
+          isDisabled={!method || !api.tx.ethCall.call}
+          label={t<string>('Sign Transaction')}
+          onClick={_onClickSignCall}
+        />
+      </Button.Group>
+      {errorMessage && (
+        <article className='error padded'>
+          <div>
+            <Icon icon='ban' />
+            {errorMessage.message}
+          </div>
+        </article>
+      )}
+    </div>
+  );
+}
+
+export default React.memo(styled(CustomSignTx)`
+
+`);

--- a/packages/page-custom-signature/src/EcdsaCallSigner/EcdsaAccount.tsx
+++ b/packages/page-custom-signature/src/EcdsaCallSigner/EcdsaAccount.tsx
@@ -1,0 +1,114 @@
+// Copyright 2017-2020 @polkadot/app-custom-signature authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback, useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+// note: this pull the chain metadata from the settings page to make the code shorter
+import useChainInfo from '@polkadot/app-settings/useChainInfo';
+import { AddressMini, Button, Icon } from '@polkadot/react-components';
+
+import { useTranslation } from '../translate';
+import { EcdsaAddressFormat } from '../types';
+import { useMetaMask } from '../useMetaMask';
+import * as utils from '../utils';
+
+interface Props {
+  className?: string;
+  onAccountChanged?: (account?: EcdsaAddressFormat) => void;
+}
+
+function EcdsaAccount ({ className = '', onAccountChanged }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+  const { activateMetaMask, ethereum, loadedAccounts } = useMetaMask();
+  const chainInfo = useChainInfo();
+  // internal message state
+  const [errorMessage, setErrorMessage] = useState<Error>();
+  // note: currently, MetaMask will only export one account at a time.
+  // so this value will always be either an empty array or an array with one item.
+  const [ecdsaAccounts, setEcdsaAccounts] = useState<EcdsaAddressFormat>();
+
+  const [isBusy, setIsBusy] = useState(false);
+
+  const _onClickLoadAccount = useCallback(async () => {
+    setIsBusy(true);
+
+    try {
+      // reset the error message if it already exists
+      if (typeof errorMessage !== 'undefined') {
+        setErrorMessage(undefined);
+      }
+
+      // fetch the current active account from MetaMask
+      const accounts = await activateMetaMask();
+      const loadingAddr = accounts[0];
+      const loginMsg = `Sign this message to login with address ${loadingAddr}`;
+
+      // send a signature method to sign an arbitrary message
+      // note: we only get the first account for now
+      const signature = await ethereum?.request({ method: 'personal_sign', params: [loadingAddr, loginMsg] });
+      // recover the ethereum ECDSA compressed public key from the signature
+      const pubKey = utils.recoverPublicKeyFromSig(loadingAddr, loginMsg, signature as string);
+
+      console.log(`Public key: ${pubKey}`);
+      // encode the public key to Substrate-compatible ss58
+      // note: the default prefix is `42`, which is for the dev node
+      const ss58Address = utils.ecdsaPubKeyToSs58(pubKey, chainInfo?.ss58Format);
+
+      setEcdsaAccounts({ ethereum: loadingAddr, ss58: ss58Address });
+    } catch (err) {
+      setErrorMessage(err);
+    } finally {
+      setIsBusy(false);
+    }
+  }, [activateMetaMask, chainInfo, ethereum, errorMessage]);
+
+  // reset the account cache if the user changes their account in MetaMask
+  useEffect(() => {
+    // check if the selected account is different from the loaded account
+    if (loadedAccounts.length > 0 && ecdsaAccounts?.ethereum !== loadedAccounts[0]) {
+      setEcdsaAccounts(undefined);
+    }
+  }, [ecdsaAccounts, loadedAccounts]);
+
+  // emit the account change event handler
+  useEffect(() => {
+    onAccountChanged && onAccountChanged(ecdsaAccounts);
+  }, [ecdsaAccounts, onAccountChanged]);
+
+  return (
+    <div className={`${className}`}>
+      {typeof ecdsaAccounts === 'undefined'
+        ? (
+          <>
+            <Button
+              icon='sync'
+              isBusy={isBusy}
+              label={t<string>('Load account from MetaMask')}
+              onClick={_onClickLoadAccount}
+            />
+          </>
+        )
+        : (
+          <>
+            <AddressMini label='Current Account'
+              value={ecdsaAccounts.ss58}
+              withBalance />
+          </>
+        )
+      }
+      {errorMessage && (
+        <article className='error padded'>
+          <div>
+            <Icon icon='ban' />
+            {errorMessage.message}
+          </div>
+        </article>
+      )}
+    </div>
+  );
+}
+
+export default React.memo(styled(EcdsaAccount)`
+
+`);

--- a/packages/page-custom-signature/src/EcdsaCallSigner/index.tsx
+++ b/packages/page-custom-signature/src/EcdsaCallSigner/index.tsx
@@ -1,0 +1,43 @@
+// Copyright 2017-2020 @polkadot/app-custom-signature authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import React, { useCallback, useState } from 'react';
+
+import { EcdsaAddressFormat } from '../types';
+import { useMetaMask } from '../useMetaMask';
+import CustomSignTx from './CustomSignTx';
+import EcdsaAccount from './EcdsaAccount';
+
+interface Props {
+  className: string;
+}
+
+function EcdsaCallSigner ({ className = '' }: Props): React.ReactElement<Props> {
+  const { ethereum } = useMetaMask();
+  const [currentEthAddress, setCurrentEthAddress] = useState<EcdsaAddressFormat>();
+
+  // request signature from MetaMask
+  const _onClickSignatureRequest = useCallback(async (payload: string) => {
+    // we're signing the message with the first account
+    const extensionMethodPayload = { method: 'personal_sign', params: [currentEthAddress?.ethereum, payload] };
+
+    console.log(`Sending method ${JSON.stringify(extensionMethodPayload)}`);
+
+    const signature = (await ethereum?.request(extensionMethodPayload)) as string;
+
+    return signature;
+  }, [ethereum, currentEthAddress]);
+
+  return (
+    <section className={`${className}`}>
+      <EcdsaAccount
+        onAccountChanged={setCurrentEthAddress}
+      />
+      {currentEthAddress && (<CustomSignTx onClickSignTx={_onClickSignatureRequest}
+        sender={currentEthAddress.ss58}/>)}
+
+    </section>
+  );
+}
+
+export default React.memo(EcdsaCallSigner);

--- a/packages/page-custom-signature/src/index.tsx
+++ b/packages/page-custom-signature/src/index.tsx
@@ -1,0 +1,38 @@
+// Copyright 2017-2020 @polkadot/app-js authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { AppProps as Props } from '@polkadot/react-components/types';
+
+import React, { useRef } from 'react';
+
+import { Tabs } from '@polkadot/react-components';
+
+import EcdsaCallSigner from './EcdsaCallSigner';
+import { useTranslation } from './translate';
+
+function CustomSignatureApp ({ basePath }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
+
+  const itemsRef = useRef([
+    {
+      isRoot: true,
+      name: 'index',
+      text: t<string>('Sign Transaction')
+    }
+  ]);
+
+  return (
+    <main>
+      <header>
+        <Tabs
+          basePath={basePath}
+          items={itemsRef.current}
+        />
+      </header>
+      <EcdsaCallSigner />
+
+    </main>
+  );
+}
+
+export default React.memo(CustomSignatureApp);

--- a/packages/page-custom-signature/src/translate.ts
+++ b/packages/page-custom-signature/src/translate.ts
@@ -1,0 +1,10 @@
+// Copyright 2017-2020 @polkadot/app-custom-signature authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { UseTranslationResponse } from 'react-i18next';
+
+import { useTranslation as useTranslationBase } from 'react-i18next';
+
+export function useTranslation (): UseTranslationResponse<string> {
+  return useTranslationBase('app-custom-signature');
+}

--- a/packages/page-custom-signature/src/types.ts
+++ b/packages/page-custom-signature/src/types.ts
@@ -1,0 +1,32 @@
+// Copyright 2017-2020 @polkadot/app-custom-signature authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export interface ComponentProps {
+  allAccounts: string[];
+  className?: string;
+  isMine: boolean;
+  sudoKey?: string;
+}
+
+// Ethereum provider types
+interface RequestArguments {
+  method: string;
+  params?: unknown[] | Record<string, unknown>;
+}
+
+export interface EthereumProvider {
+  isMetaMask?: boolean;
+  on: (event: string, handler: (response: any) => void) => void;
+  request: (args: RequestArguments) => Promise<unknown>;
+}
+
+export interface EcdsaAddressFormat {
+  ethereum: string;
+  ss58: string;
+}
+
+declare global {
+  interface Window {
+    ethereum?: EthereumProvider;
+  }
+}

--- a/packages/page-custom-signature/src/useEthProvider.ts
+++ b/packages/page-custom-signature/src/useEthProvider.ts
@@ -1,0 +1,25 @@
+// Copyright 2017-2020 @polkadot/react-hooks authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+
+import { useIsMountedRef } from '@polkadot/react-hooks';
+
+import { EthereumProvider } from './types';
+
+interface UseEthProvider {
+  provider?: EthereumProvider;
+}
+
+export function useEthProvider (): UseEthProvider {
+  const mountedRef = useIsMountedRef();
+  const [ethProvider, setEthProvider] = useState<EthereumProvider>();
+
+  useEffect(() => {
+    if (mountedRef.current && window.ethereum) {
+      setEthProvider(window.ethereum);
+    }
+  }, [mountedRef]);
+
+  return { provider: ethProvider };
+}

--- a/packages/page-custom-signature/src/useMetaMask.ts
+++ b/packages/page-custom-signature/src/useMetaMask.ts
@@ -1,0 +1,51 @@
+// Copyright 2017-2020 @polkadot/app-custom-signature authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { EthereumProvider } from './types';
+import { useEthProvider } from './useEthProvider';
+
+interface UseMetaMask {
+  loadedAccounts: string[];
+  activateMetaMask: () => Promise<string[]>;
+  ethereum?: EthereumProvider;
+}
+
+export function useMetaMask (): UseMetaMask {
+  const { provider } = useEthProvider();
+  const [loadedAccounts, setLoadedAccounts] = useState<string[]>([]);
+
+  const requestAccounts = useCallback(async () => {
+    if (typeof provider === 'undefined') {
+      throw new Error('Cannot detect MetaMask');
+    }
+
+    const accounts = (await provider.request({ method: 'eth_requestAccounts' })) as string[];
+
+    setLoadedAccounts(accounts);
+
+    return accounts;
+  }, [provider]);
+
+  useEffect(() => {
+    if (provider?.isMetaMask) {
+      const ethereum = provider;
+
+      // handle account changes
+      // fixme: this event is being called multiple times
+      ethereum.on('accountsChanged', (accounts: string[]) => {
+        setLoadedAccounts(accounts);
+
+        console.log(`User changed account to ${accounts[0]}`);
+      });
+
+      ethereum.on('chainChanged', () => {
+        // refresh the page if the user changes the network
+        window.location.reload();
+      });
+    }
+  }, [provider]);
+
+  return { activateMetaMask: requestAccounts, ethereum: provider, loadedAccounts };
+}

--- a/packages/page-custom-signature/src/utils.ts
+++ b/packages/page-custom-signature/src/utils.ts
@@ -1,0 +1,72 @@
+// Copyright 2017-2020 @polkadot/app-custom-signature authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import * as ethUtils from 'ethereumjs-util';
+import { publicKeyConvert } from 'secp256k1';
+
+import { hexToU8a, isHex, u8aToHex } from '@polkadot/util';
+import { blake2AsU8a, encodeAddress, isEthereumAddress } from '@polkadot/util-crypto';
+
+/**
+ * Converts ECDSA public key into a valid ss58 address for Substrate.
+ * Note that this is different from the EVM-mapped Ethereum addresses.
+ * @param publicKey a 33-byte compressed ECDSA public key in hex string
+ * @param networkPrefix the ss58 format used to encode the resulting address
+ */
+export const ecdsaPubKeyToSs58 = (publicKey: string, networkPrefix?: number): string => {
+  if (!isHex(publicKey)) {
+    throw new Error('Public key is not 0x-prefixed');
+  }
+
+  if (hexToU8a(publicKey).length !== 33) {
+    throw new Error(`Expected a 33 byte compressed public key, instead got ${publicKey}`);
+  }
+
+  const ss58PubKey = blake2AsU8a(hexToU8a(publicKey), 256);
+  const ss58Address = encodeAddress(ss58PubKey, networkPrefix);
+
+  return ss58Address;
+};
+
+/**
+ * Recovers the compressed public key from an ECDSA signature signed by the `personal_sign` method.
+ * @param address ethereum public address of the signer
+ * @param msgString message string that was signed
+ * @param rpcSig resulting signature in hex string
+ */
+export const recoverPublicKeyFromSig = (address: string, msgString: string, rpcSig: string): string => {
+  // check if the message is hex encoded or not
+  const encodingType = isHex(msgString) ? 'hex' : 'utf8';
+  // message hashing is done here, which includes the message prefix
+  const msgHash = ethUtils.hashPersonalMessage(Buffer.from(msgString, encodingType));
+
+  const signature = ethUtils.fromRpcSig(rpcSig);
+
+  if (!ethUtils.isValidSignature(signature.v, signature.r, signature.s)) {
+    throw new Error('Invalid signature provided');
+  }
+
+  if (!isEthereumAddress(address)) {
+    throw new Error('Invalid address provided');
+  }
+
+  const publicKey = ethUtils.ecrecover(msgHash, signature.v, signature.r, signature.s);
+  const recoveredAddress = ethUtils.bufferToHex(ethUtils.pubToAddress(publicKey));
+
+  if (recoveredAddress !== address) {
+    throw new Error(`Expected ${address}, but recovered address is ${recoveredAddress}`);
+  }
+
+  // note: hex string from buffer is not 0x prefixed
+  let prefixedPubKey = publicKey.toString('hex');
+
+  // add a 04 prefix to the uncompressed public key if it hasn't been added
+  if (publicKey.length === 64) {
+    prefixedPubKey = '04' + prefixedPubKey;
+  }
+
+  // compress the public key
+  const compressedKey = publicKeyConvert(Buffer.from(prefixedPubKey, 'hex'), true);
+
+  return u8aToHex(compressedKey);
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,8 @@
       "@polkadot/app-contracts/*": [ "packages/page-contracts/src/*" ],
       "@polkadot/app-council": [ "packages/page-council/src" ],
       "@polkadot/app-council/*": [ "packages/page-council/src/*" ],
+      "@polkadot/app-custom-signature": ["packages/page-custom-signature/src"],
+      "@polkadot/app-custom-signature/*": ["packages/page-custom-signature/src/*"],
       "@polkadot/app-democracy": [ "packages/page-democracy/src" ],
       "@polkadot/app-democracy/*": [ "packages/page-democracy/src/*" ],
       "@polkadot/app-extrinsics": [ "packages/page-extrinsics/src" ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,6 +2032,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@polkadot/app-custom-signature@workspace:packages/page-custom-signature":
+  version: 0.0.0-use.local
+  resolution: "@polkadot/app-custom-signature@workspace:packages/page-custom-signature"
+  dependencies:
+    "@babel/runtime": ^7.12.5
+    "@polkadot/react-components": ^0.75.2-53
+    ethereumjs-util: ^7.0.7
+    secp256k1: ^3.8.0
+  languageName: unknown
+  linkType: soft
+
 "@polkadot/app-democracy@workspace:packages/page-democracy":
   version: 0.0.0-use.local
   resolution: "@polkadot/app-democracy@workspace:packages/page-democracy"
@@ -2244,6 +2255,7 @@ __metadata:
     "@polkadot/react-query": ^0.75.2-53
     "@polkadot/react-signer": ^0.75.2-53
     "@types/punycode": ^2.1.0
+    assert: ^2.0.0
     babel-loader: ^8.2.2
     buffer: ^6.0.3
     copy-webpack-plugin: ^7.0.0
@@ -3098,7 +3110,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bn.js@npm:^4.11.6":
+"@types/bn.js@npm:^4.11.3, @types/bn.js@npm:^4.11.6":
   version: 4.11.6
   resolution: "@types/bn.js@npm:4.11.6"
   dependencies:
@@ -3414,6 +3426,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/pbkdf2@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "@types/pbkdf2@npm:3.1.0"
+  dependencies:
+    "@types/node": "*"
+  checksum: 384afdeb38c70d5e2e2b7593832eef5ca229bcc452df8c6a66a273fe078fedebf82034790d1532c8c199dfb4be829054904432395862ef3727859bdbc62a0f48
+  languageName: node
+  linkType: hard
+
 "@types/plist@npm:^3.0.1":
   version: 3.0.2
   resolution: "@types/plist@npm:3.0.2"
@@ -3523,6 +3544,15 @@ __metadata:
   version: 0.12.0
   resolution: "@types/retry@npm:0.12.0"
   checksum: 0755164f2c8d615a0385609c478aaa20b17e55bc8b16d5d56ffe6a5d30b0a9845d49452a2e8903ec7c43fa361f19daf5e68c60e7381ad10a95dd3d0bb5c9f7fd
+  languageName: node
+  linkType: hard
+
+"@types/secp256k1@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@types/secp256k1@npm:4.0.1"
+  dependencies:
+    "@types/node": "*"
+  checksum: 4e356a4df5fa9aa2f15979144e9ebf4bad1eb57870dcdf2176446c6619af692e1e68452905814c9279ac0ef6ae160503cf64f995fde5d638358feed9b434dd16
   languageName: node
   linkType: hard
 
@@ -4611,6 +4641,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assert@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "assert@npm:2.0.0"
+  dependencies:
+    es6-object-assign: ^1.1.0
+    is-nan: ^1.2.1
+    object-is: ^1.0.1
+    util: ^0.12.0
+  checksum: c3593bcc4c63c1e6fd3b62a7c788cf7337118d79b827d79b0ed60e596d4968b80b2f8aa8e41bc5742621596bd60aa9de62ea166d85a584a6db177d7087e907f3
+  languageName: node
+  linkType: hard
+
 "assign-symbols@npm:^1.0.0":
   version: 1.0.0
   resolution: "assign-symbols@npm:1.0.0"
@@ -5046,14 +5088,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.8, bn.js@npm:^4.11.9, bn.js@npm:^4.4.0":
+"bn.js@npm:^4.0.0, bn.js@npm:^4.1.0, bn.js@npm:^4.11.1, bn.js@npm:^4.11.8, bn.js@npm:^4.11.9, bn.js@npm:^4.4.0":
   version: 4.11.9
   resolution: "bn.js@npm:4.11.9"
   checksum: 31630d3560b28931010980886a0f657b37ce818ba237867cd838e89a1a0b71044fb4977aa56376616997b372bbb3f55d3bb25e5378c48c1d24a47bfb4235b60e
   languageName: node
   linkType: hard
 
-"bn.js@npm:^5.0.0, bn.js@npm:^5.1.1":
+"bn.js@npm:^5.0.0, bn.js@npm:^5.1.1, bn.js@npm:^5.1.2":
   version: 5.1.3
   resolution: "bn.js@npm:5.1.3"
   checksum: 991c1fefb03bd69315297d454b379d5a5dd4834ab97db3ec985714f00ff7d3cc19642e1ac6bdf0d9f04946cc9f1ad26a5b497b7f4e7fa1230caf68af46fbefe6
@@ -5173,7 +5215,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserify-aes@npm:^1.0.0, browserify-aes@npm:^1.0.4, browserify-aes@npm:^1.0.6":
+"browserify-aes@npm:^1.0.0, browserify-aes@npm:^1.0.4, browserify-aes@npm:^1.0.6, browserify-aes@npm:^1.2.0":
   version: 1.2.0
   resolution: "browserify-aes@npm:1.2.0"
   dependencies:
@@ -5252,12 +5294,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs58@npm:^4.0.1":
+"bs58@npm:^4.0.0, bs58@npm:^4.0.1":
   version: 4.0.1
   resolution: "bs58@npm:4.0.1"
   dependencies:
     base-x: ^3.0.2
   checksum: 0da897a0e527b31ec0fd7ce4d84a86278196acb4fa4f5010dce38a7b83b8b0bbe26909843878c2aa32bdbe00b93a68408d42c74a1cfaa05ca64f29bd5dff4187
+  languageName: node
+  linkType: hard
+
+"bs58check@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "bs58check@npm:2.1.2"
+  dependencies:
+    bs58: ^4.0.0
+    create-hash: ^1.1.0
+    safe-buffer: ^5.1.2
+  checksum: 43e75980883bff36a591a8ecf790e3b1f4d7cf03bf2a4866f371355e2de121f9130ac41e1abf28451ccf808e32f589048da6250fa9e15d3f766d871ca39f6d67
   languageName: node
   linkType: hard
 
@@ -7857,6 +7910,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es6-object-assign@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "es6-object-assign@npm:1.1.0"
+  checksum: 18f01190b46b15a5fd6275dfc37c1c10bb331be4e392362785f63a141aa33edd0d8fbd2d5150c4b0a524aa14b8c4f825a559274cbc765bce59331e015923b4d8
+  languageName: node
+  linkType: hard
+
 "es6-symbol@npm:^3.1.1, es6-symbol@npm:~3.1.3":
   version: 3.1.3
   resolution: "es6-symbol@npm:3.1.3"
@@ -8250,6 +8310,53 @@ __metadata:
   dependencies:
     pnglib: 0.0.1
   checksum: 7a02af1c7a4ee2781bbcecae8605985340eb2ba1b030997a7982b349c1d2c180f836bb50488184a1ff38420b60f5437b97f52d30e550fff13835c47009111f23
+  languageName: node
+  linkType: hard
+
+"ethereum-cryptography@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "ethereum-cryptography@npm:0.1.3"
+  dependencies:
+    "@types/pbkdf2": ^3.0.0
+    "@types/secp256k1": ^4.0.1
+    blakejs: ^1.1.0
+    browserify-aes: ^1.2.0
+    bs58check: ^2.1.2
+    create-hash: ^1.2.0
+    create-hmac: ^1.1.7
+    hash.js: ^1.1.7
+    keccak: ^3.0.0
+    pbkdf2: ^3.0.17
+    randombytes: ^2.1.0
+    safe-buffer: ^5.1.2
+    scrypt-js: ^3.0.0
+    secp256k1: ^4.0.1
+    setimmediate: ^1.0.5
+  checksum: dd0c177dc4ed8a98cf9f821947cc5b6cc4f8088cac9fce1f7ea4577721ab42f24db661db13930a39e59c8bef50e7f979e721ee34c41019b404d2d530d5520327
+  languageName: node
+  linkType: hard
+
+"ethereumjs-util@npm:^7.0.7":
+  version: 7.0.7
+  resolution: "ethereumjs-util@npm:7.0.7"
+  dependencies:
+    "@types/bn.js": ^4.11.3
+    bn.js: ^5.1.2
+    create-hash: ^1.1.2
+    ethereum-cryptography: ^0.1.3
+    ethjs-util: 0.1.6
+    rlp: ^2.2.4
+  checksum: da266c668416756853d3f33b13ad8674c26fd0fa50ea020c722418bedc7be26f0b0ef2ed6761cee17732466fd5ccac471b0a6802a9893c32af2885ab7ccec565
+  languageName: node
+  linkType: hard
+
+"ethjs-util@npm:0.1.6":
+  version: 0.1.6
+  resolution: "ethjs-util@npm:0.1.6"
+  dependencies:
+    is-hex-prefixed: 1.0.0
+    strip-hex-prefix: 1.0.0
+  checksum: 3ba90234cc4219983203e0dfcf5789f149c3f691ecba18a774b4d2d348aefee02d8d56b947237ec65639d0fd4338598320332f9a86b24844b0ccba1f649ac8b7
   languageName: node
   linkType: hard
 
@@ -10684,6 +10791,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"is-hex-prefixed@npm:1.0.0":
+  version: 1.0.0
+  resolution: "is-hex-prefixed@npm:1.0.0"
+  checksum: f873105d8d2bf4d4fda29ecf111a6db10d398bcf8ed8c9d2f52397f642c44322a414a8d4af70df3fd758403cbf0d65be04608ed587a190c7d355ffb607bfb50f
+  languageName: node
+  linkType: hard
+
 "is-hexadecimal@npm:^1.0.0":
   version: 1.0.4
   resolution: "is-hexadecimal@npm:1.0.4"
@@ -10728,6 +10842,16 @@ fsevents@~2.1.2:
     multibase: ~0.6.0
     multihashes: ~0.4.13
   checksum: 0705cdcdb690b3a97903cffa8d72c076be99e55bcbaa43bd6d9a898c7403fedd5fcde99d037313eec5d5779852bd240f9f57844bf3c71ff0ba0cfce08ec74164
+  languageName: node
+  linkType: hard
+
+"is-nan@npm:^1.2.1":
+  version: 1.3.2
+  resolution: "is-nan@npm:1.3.2"
+  dependencies:
+    call-bind: ^1.0.0
+    define-properties: ^1.1.3
+  checksum: 258ecdd2c149c4e073a3c7dff0ee1316950509d9a507c6f8e8ccce8c4ef73e9f29cdf7836cc1037bbbada283ac9fe189c0451016a9aca6c27eb12eaa900452f8
   languageName: node
   linkType: hard
 
@@ -11799,6 +11923,17 @@ fsevents@~2.1.2:
     array-includes: ^3.1.2
     object.assign: ^4.1.2
   checksum: 2a8033e63234d04e6ed77ac91222e2dff527f64cf70c10d2f26fda6f35dc9b78d5e3a43fc3d28df7fe0dab45294b94c9c90e58ab242ecf14e58cd39691ee0ed4
+  languageName: node
+  linkType: hard
+
+"keccak@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "keccak@npm:3.0.1"
+  dependencies:
+    node-addon-api: ^2.0.0
+    node-gyp: latest
+    node-gyp-build: ^4.2.0
+  checksum: 78b5f8331a5c2f7dbabd571aec4af4df2ec57aa70f2de8525f1f4c2965a7638d576c96f8e2baf258b41589d8b0ca6f7f674fb919a70d5c7f2839263fef7c56a1
   languageName: node
   linkType: hard
 
@@ -13089,6 +13224,15 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"node-addon-api@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "node-addon-api@npm:2.0.2"
+  dependencies:
+    node-gyp: latest
+  checksum: c40748948918fc82b83a9f3442a98f4fa92bd9786bb1d1b507facf77a22fb7a4b5b9332102f6ad94c7e2828ae3cd353907cbaa8eaf4ce9c5edaa9d327d501301
+  languageName: node
+  linkType: hard
+
 "node-addon-api@npm:^3.0.2":
   version: 3.1.0
   resolution: "node-addon-api@npm:3.1.0"
@@ -14039,7 +14183,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"pbkdf2@npm:^3.0.3":
+"pbkdf2@npm:^3.0.17, pbkdf2@npm:^3.0.3":
   version: 3.1.1
   resolution: "pbkdf2@npm:3.1.1"
   dependencies:
@@ -15785,6 +15929,17 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"rlp@npm:^2.2.4":
+  version: 2.2.6
+  resolution: "rlp@npm:2.2.6"
+  dependencies:
+    bn.js: ^4.11.1
+  bin:
+    rlp: bin/rlp
+  checksum: 58777508e10d6ec39efcb14f85fd80dc07f549a60dfc51f1b59c62a5e1d32ef92ff6721f77aa767dfb41f2c5027c408c79dcbd1c63aa38915714969600ecd9d7
+  languageName: node
+  linkType: hard
+
 "roarr@npm:^2.15.3":
   version: 2.15.4
   resolution: "roarr@npm:2.15.4"
@@ -15955,6 +16110,13 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
+"scrypt-js@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "scrypt-js@npm:3.0.1"
+  checksum: 2ae93c4dd519c05a53c169fb92bbc2f76c38c7b2a277492e098f300caf099ccfae07de06441f9a9af4fceda1af65c9fff3a1af6b33da293586cd3ea33db7d40d
+  languageName: node
+  linkType: hard
+
 "scryptsy@npm:^2.1.0":
   version: 2.1.0
   resolution: "scryptsy@npm:2.1.0"
@@ -15983,6 +16145,18 @@ fsevents@~2.1.2:
     node-gyp: latest
     safe-buffer: ^5.1.2
   checksum: 8c3c8fa6c0db00fd295f5cba4efe84beaacc563f2f63a4b82519141658bbde8893988976035eb4aed67e612cad87952598c16ed6e83a64331b1f10916647ebe1
+  languageName: node
+  linkType: hard
+
+"secp256k1@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "secp256k1@npm:4.0.2"
+  dependencies:
+    elliptic: ^6.5.2
+    node-addon-api: ^2.0.0
+    node-gyp: latest
+    node-gyp-build: ^4.2.0
+  checksum: 5bf0e0aa119602c96fb26c87b4707d314e6e85d5b6aca8b6286e781b3c573775cabd68e4e6d90dcabe915a4795743e2f208dcc556e7c11b1a89b19dc5c64434e
   languageName: node
   linkType: hard
 
@@ -16176,6 +16350,13 @@ fsevents@~2.1.2:
     is-plain-object: ^2.0.3
     split-string: ^3.0.1
   checksum: a97a99a00cc5ed3034ccd690ff4dde167e4182ec4ef2fd5277637a6e388839292559301408b91405534b44e76450bdd443ac95427fde40e9a1a62102c1262bd1
+  languageName: node
+  linkType: hard
+
+"setimmediate@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "setimmediate@npm:1.0.5"
+  checksum: 87884d8add4779fe47ccf763396a5bf875640ae34d80a10802da4de5c25d87647c12f6e7748fd5b8c143b57201caf2a5a781631456c228825f166ca305c12f20
   languageName: node
   linkType: hard
 
@@ -17028,6 +17209,15 @@ fsevents@~2.1.2:
   version: 2.0.0
   resolution: "strip-final-newline@npm:2.0.0"
   checksum: 74dbd8a602409706748db730200efab53ba739ed7888310e74e45697efbd760981df6d6f0fa34b23e973135fb07d3b22adae6e6d58898f692a094e49692c6c33
+  languageName: node
+  linkType: hard
+
+"strip-hex-prefix@npm:1.0.0":
+  version: 1.0.0
+  resolution: "strip-hex-prefix@npm:1.0.0"
+  dependencies:
+    is-hex-prefixed: 1.0.0
+  checksum: 38a438000f8f95ee93596d6905c27ad13a9f9f3249522248442b954000f2ca527b0a952cb90ddf4df36108b523948d0a76252b62513522de5c93313b5eb82e1a
   languageName: node
   linkType: hard
 
@@ -18351,7 +18541,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"util@npm:^0.12.3":
+"util@npm:^0.12.0, util@npm:^0.12.3":
   version: 0.12.3
   resolution: "util@npm:0.12.3"
   dependencies:


### PR DESCRIPTION
## Feature Summary

> Related to [this grant milestone](https://github.com/w3f/Grant-Milestone-Delivery/pull/83)

This pull request adds the Custom Signature page under the Account tab.
The Custom Signature page allows the user to submit a transaction that was signed with an Ethereum private key and use it as a native ECDSA account in Substrate. Plus, you are able to use MetaMask for signature requests, which allows users to use their Ethereum address inside Ledger and Trezor to create a transaction.

## Preview

https://user-images.githubusercontent.com/40356749/104814290-7137a700-5851-11eb-8cef-00b9495da0d6.mp4

<img width="600" alt="IMG_0796" src="https://user-images.githubusercontent.com/40356749/104814283-667d1200-5851-11eb-9b72-e7ef8e810eb4.jpeg">

<img width="600" alt="Screen Shot 2021-01-15 at 1 06 30 AM" src="https://user-images.githubusercontent.com/40356749/104814287-69780280-5851-11eb-83a9-03edf658fa8d.png">

## Notable Changes

- add `assert` browser polyfill that is used by the `ethereumjs-util` package
- add basic zero-dependency MetaMask support to the Custom Signature page (only works on that page)
- add `custom-signature` page that will be available for chains that implement the `custom-signatures` pallet (https://github.com/PlasmNetwork/Plasm/tree/dusty/frame/custom-signatures) as `EthCall` (https://github.com/PlasmNetwork/Plasm/blob/feature/vectorized-custom-signatures/bin/node/runtime/src/lib.rs#L649)
- add Ethereum account to SS58 ECDSA account converter

## Usage

Currently, this page is made with MetaMask in mind. Most browser-injected ethereum wallets that use the `window.ethereum` object and accept the `personal_sign` method should be compatible, but please understand that there may be unexpected errors.

You can learn more about the usage from this doc: https://docs.plasmnet.io/workshop-and-tutorial/metamask-signatures